### PR TITLE
Add config interval option to snap to grid center

### DIFF
--- a/scripts/crosshairs.js
+++ b/scripts/crosshairs.js
@@ -337,11 +337,17 @@ export class Crosshairs extends MeasuredTemplate {
     const snapped = canvas.grid.getSnappedPosition(x, y, interval);
     if (this.centerOnSquare) {
       const { size } = canvas.grid;
-      if (!(snapped.x % size)) {
-        snapped.x += size / 2;
+      if (snapped.x % size === 0) {
+        const changeX = x > snapped.x
+          ? size / 2
+          : -size / 2;
+        snapped.x += changeX;
       }
-      if (!(snapped.y % size)) {
-        snapped.y += size / 2;
+      if (snapped.y % size === 0) {
+        const changeY = y > snapped.y
+          ? size / 2
+          : -size / 2;
+        snapped.y += changeY;
       }
     }
     return snapped;

--- a/scripts/crosshairs.js
+++ b/scripts/crosshairs.js
@@ -72,7 +72,7 @@ export class Crosshairs extends MeasuredTemplate {
         this.interval = 2;
         break;
       default:
-        this.interval = config.interval;
+        this.interval = +config.interval;
         break;
     }
 

--- a/scripts/crosshairs.js
+++ b/scripts/crosshairs.js
@@ -336,11 +336,12 @@ export class Crosshairs extends MeasuredTemplate {
   _getSnappedPosition({ x, y }, interval) {
     const snapped = canvas.grid.getSnappedPosition(x, y, interval);
     if (this.centerOnSquare) {
-      if (!(snapped.x % canvas.grid.size)) {
-        snapped.x += canvas.grid.size / 2;
+      const { size } = canvas.grid;
+      if (!(snapped.x % size)) {
+        snapped.x += size / 2;
       }
-      if (!(snapped.y % canvas.grid.size)) {
-        snapped.y += canvas.grid.size / 2;
+      if (!(snapped.y % size)) {
+        snapped.y += size / 2;
       }
     }
     return snapped;


### PR DESCRIPTION
I overloaded the `interval` param to also accept `'corner'` and `'center'` to optionally instead snap to the corner of a grid square or the center of a grid square. (`'corner'` behaves exactly as setting interval to `1`. It's included just for completeness since it makes sense as an option knowing that `'center'` is also an option).

Getting the center is done by essentially using a snap of `2` and then just bumping up the x/y to any snaps that are on a grid line. So the modulo math is just checking if the returned snap is directly on a grid line, if it is, then it's just adding a half a grid size to the x/y value on the snap object--thus every snapped object returned is guaranteed to be in the middle of a square.

p.s. I didn't update the readme or any of the inline comments here, so if something is out of sync those should be included. I also just copied the changes I made locally into github's editor so if it doesn't work then I missed something--but it's pretty straightforward so I'm pretty sure I grabbed it all (if I didn't feel free to ping me, but it's simple enough it'll probably be obvious what's missing in that case)

closes #21 