### PR TITLE
Added firstGM, isFirstGM, firstOwner and isFirstOwner to api. Fixed bug with isFirstOwner

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,30 @@ Advanced dialog helper providing multiple input type options as well as user def
   - `inputs` Array of the same type as [dialog's](#dialog) return value.
   - `buttons` A single value corresponding to the `value` of button pressed. If no buttons were provided the default button's return value is `true`. If the menu is closed, this value is `false`.
 
+### firstGM
+	
+Signature: `warpgate.firstGM()`
+	
+A helper functions that returns the first active GM level user.
+
+### isFirstGM
+	
+Signature: `warpgate.isFirstGM()`
+
+Checks whether the user calling this function is the user returned by warpgate.firstGM(). Returns true if they are, false if they are not.
+	
+### firstOwner
+
+Signature: `warpgate.firstOwner(document)`
+
+Returns the first active user with owner permissions for the given document, falling back to the firstGM should there not be any. Returns false if the document is falsey. In the case of token documents it checks the permissions for the token's actor as tokens themselves do not have a permission object.
+	
+### isFirstOwner
+
+Signature: `warpgate.isFirstOwner(document)`
+
+Checks whether the user calling this function is the user returned by warpgate.firstOwner() when the function is passed the given document. Returns true if they are the same, false if they are not.
+	
 ## Update Shorthand
 The `update` object can contain up to three keys: `token`, `actor`, and `embedded`. The `token` and `actor` key values are standard update objects as one would use in `Actor#update` and `Token#update`.  The `embedded` key uses a shorthand notation to make creating the updates for embedded documents (such as items) easier. Notably, it does not require the `_id` field to be part of the update object for a given embedded document type.  There are three operations that this object controls -- adding, updating, deleting (in that order).
 

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -48,6 +48,10 @@ export class api {
       dialog : MODULE.dialog,
       menu: MODULE.menu,
       buttonDialog : MODULE.buttonDialog,
+      firstGM:MODULE.firstGM,
+      isFirstGM:MODULE.isFirstGM,
+      firstOwner:MODULE.firstOwner,
+      isFirstOwner:MODULE.isFirstOwner,
       // \MOVE
       crosshairs: {
         show: Gateway.showCrosshairs,

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -45,10 +45,8 @@ export class MODULE {
   static firstOwner(doc) {
     /* null docs could mean an empty lookup, null docs are not owned by anyone */
     if (!doc) return false;
-    const permissionObject=(doc instanceof TokenDocument ? doc.actor.data.permission : doc.data.permission)
-    const playerOwners = Object.entries(
-      permissionObject ?? {}
-      )
+    const permissionObject=(doc instanceof TokenDocument ? doc.actor.data.permission : doc.data.permission) ?? {}
+    const playerOwners = Object.entries(permissionObject)
       .filter(([id, level]) => (!game.users.get(id)?.isGM && game.users.get(id)?.active) && level === 3)
       .map(([id, level]) => id);
     

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -45,11 +45,13 @@ export class MODULE {
   static firstOwner(doc) {
     /* null docs could mean an empty lookup, null docs are not owned by anyone */
     if (!doc) return false;
-
-    const playerOwners = Object.entries(doc.data.permission ?? {})
+    const permissionObject=(doc instanceof TokenDocument ? doc.actor.data.permission : doc.data.permission)
+    const playerOwners = Object.entries(
+      permissionObject ?? {}
+      )
       .filter(([id, level]) => (!game.users.get(id)?.isGM && game.users.get(id)?.active) && level === 3)
       .map(([id, level]) => id);
-
+    
     if (playerOwners.length > 0) {
       return game.users.get(playerOwners[0]);
     }


### PR DESCRIPTION
Added firstGM, isFirstGM, firstOwner and isFirstOwner to the api under the global warpgate namespace
Readme has been updated to reflect this
Fixed an issue with firstOwner always returning the firstGM for token documents since the token document does not have a permissions object. Instead uses the synthetic token actor's permission object should a token document be passed. This has been tested and found to respect permission changes caused by warpgate spawning a token from an unowned actor.