### PR TITLE
"Soft" Fail for when a sheet cannot be maximized

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -249,7 +249,7 @@ export class api {
       
     }
 
-    if (options.controllingActor?.sheet?.rendered) options.controllingActor.sheet.maximize();
+    if (options.controllingActor?.sheet?.rendered) options.controllingActor?.sheet?.maximize();
     return createdIds;
   }
 


### PR DESCRIPTION
When providing the `controllingActor` argument, warpgate can error when trying to maximize a sheet, whether or not it exists.
This prevents it from stopping the code when it cannot maximize a sheet that may very well not exist.