### PR TITLE
permissions check and feedback for spawn/mutate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,11 +475,11 @@ The following table describes the stock events that occur within warpgate. All e
 | -- | -- | -- | -- |
 | <common> | {sceneId, userId} | | userId is the initiator |
 | PLACEMENT | {templateData, tokenData} | After placement has been decided | The MeasuredTemplate data used to spawn the token, and the final token data that will be spawned. There is no actor data provided.  |
-| SPAWN | {actorData, iteration} | After each token has been created | Iteration this actor was spawned on. See **actorData**, below. |
+| SPAWN | {uuid, updates, options, iteration} | After each token has been created | UUID of created token, updates applied to the token, options used for spawning, and iteration this token was spawned on.|
 | DISMISS | {actorData} | After any token is dismissed via `warpgate.dismiss` | see **actorData**, below |
-| MUTATE | {actorData, updates} | After a token has been mutated, but before the initiating client has run its post mutate callback | see **actorData**, below. |
-| REVERT | {actorData, updates} | After a token has been fully reverted to its previous state | updates are the changes that are applied to the provided actorData (see below) to produce the final reverted state. |
-| MUTATE_RESPONSE | {tokenId, mutationId, accepted, updates} | After a mutation has been accepted and applied or rejected by the owning user  | `mutationId` is the name provided in `options.name` OR a randomly assigned ID if not provided. Callback functions provided for remote mutations will be internally converted to triggers for this event and do not need to be registered manually by the user. `accepted` is a bool field that indicates if the remote user accepted the mutation. |
+| MUTATE | {uuid, updates, options} | After a token has been mutated, but before the initiating client has run its post mutate callback | UUID of modified token, updates applied to the token, options used for mutation.|
+| REVERT | {uuid, updates} | After a token has been fully reverted to its previous state | UUID of reverted token, updates applied to produce the final reverted state. |
+| MUTATE\_RESPONSE | {tokenId, mutationId, accepted, updates} | After a mutation has been accepted and applied or rejected by the owning user  | `mutationId` is the name provided in `options.name` OR a randomly assigned ID if not provided. Callback functions provided for remote mutations will be internally converted to triggers for this event and do not need to be registered manually by the user. `accepted` is a bool field that indicates if the remote user accepted the mutation. |
 
 #### actorData
 This object is a customized version of `Actor#toObject` with the following change:
@@ -488,4 +488,6 @@ This object is a customized version of `Actor#toObject` with the following chang
 ## Special Thanks
 * siliconsaint for the inspiration to turn a set of absurd macros into something usable and constantly pushing the envelope.
 * LorduFreeman for the pre and post callbacks and immediately using it for beautiful things.
-* Wasp for pushing me to make Crosshairs more full featured
+* Wasp for pushing me to make Crosshairs more full featured.
+* Arbron for the initial v9+v10 conversion updates.
+* Mr. Vaux for stretching warpgate's malleability to its limit.

--- a/lang/de.json
+++ b/lang/de.json
@@ -1,87 +1,89 @@
 {
-  "setting" : {
-    "debug" : {
-      "name" : "Debug Modus",
-      "hint" : "Aktiviert das erweiterte Debug Logging und Datensammlung"
+  "warpgate": {
+    "setting" : {
+      "debug" : {
+        "name" : "Debug Modus",
+        "hint" : "Aktiviert das erweiterte Debug Logging und Datensammlung"
+      },
+      "openDelete" : {
+        "name" : "Unbeschränkte FreigabeUnrestricted",
+        "hint" : "Erlaubt Spielern die Freigabe herrenloser Token"
+      },
+      "showDismissLabel" : {
+        "name" : "Zeige die Beschriftung des Freigabeknopfs",
+        "hint" : "Zeigt das Symbol und die Beschriftung oder nur das Symbol der Freigabefunktion."
+      },
+      "showRevertLabel" : {
+        "name" : "Zeige Beschriftung des Rückgängigknopfes",
+        "hint" : "Zeigt das Symbol und die Beschriftung oder nur das Symbol der Rückgängigfunktion."
+      },
+      "updateDelay" : {
+        "name" : "Aktualisierungsverzögerung (ms)",
+        "hint" : "Vorübergehender Workaround. Erhöhe diesen Wert wenn du Probleme mit doppelte Platzierung hast. Setze den Wert herunter für eine schnellen Platzierung."
+      },
+      "alwaysAccept": {
+        "name": "Veränderungsanfragen immer akzeptieren",
+        "hint": "Akzeptiere Veränderungen automatisch und unterdrücke den Anfragedialog."
+      },
+      "dismissButtonScope": {
+        "name": "Geltungsbereich Freigabebutton ",
+        "hint": "Legt fest, wann der Freigaebutton zu den Akteursheets hinzugefügt wird."
+      },
+      "revertButtonBehavior": {
+        "name": "Verhalten Rückgängigknopf",
+        "hint": "Standardaktion when der Knopf betätigt wird. Shift+Klick wird das zweite Verhalten ausführen."
+      },
+      "option": {
+        "disabled": "Deaktiviert",
+        "spawnedOnly": "Nur platzierte Tokens",
+        "all": "Alle Tokens im Besitz",
+        "showMutationList": "Zeige den Mutationsstapeldialog",
+        "popLatestMutation": "Mache die letzte Mutations Rückgängig"
+      }
     },
-    "openDelete" : {
-      "name" : "Unbeschränkte FreigabeUnrestricted",
-      "hint" : "Erlaubt Spielern die Freigabe herrenloser Token"
+    "debug": {
+      "dismissPresent": "Entferne vorhandene Knöpfe. Fügt keine Duplikate hinzu.",
+      "finalRevertUpdate": "Letzte rückgängig gemacht Änderung:",
+      "tokenDelta": "Token Delta",
+      "actorDelta": "Akteur Delta",
+      "embeddedDelta": "Eingebettetes Delta"
     },
-    "showDismissLabel" : {
-      "name" : "Zeige die Beschriftung des Freigabeknopfs",
-      "hint" : "Zeigt das Symbol und die Beschriftung oder nur das Symbol der Freigabefunktion."
+    "display" : {
+      "dismiss" : "Entferne",
+      "revert" : "Zurücknehmen",
+      "revertDialogTitle" : "Wähle die zurückzunehmende Mutation",
+      "inspectLabel": "Inspizieren",
+      "descriptionLabel": "Beschreibung",
+      "mutationRequestTitle": "{userName} mutiert {tokenName}",
+      "mutationAccepted": "Mutation \"{mName}\" für {tName} wurde freigegeben.",
+      "mutationRejected": "Mutation \"{mName}\" fü {tName} wurde abgelehnt.",
+      "revertAccepted": "Die Zurücknahme der Mutation [{mName}] für {tName} wurde freigegeben.",
+      "revertRejected": "Die Zurücknahme der Mutation [{mName}] für {tName} wurde abgelehnt.",
+      "revertRequestDescription": "Nehme Mutation [{mName}] von {tName} zurück.",
+      "acceptLabel": "Akzeptieren",
+      "rejectLabel": "Ablehnen",
+      "findTargetLabel": "Finde Ziel"
     },
-    "showRevertLabel" : {
-      "name" : "Zeige Beschriftung des Rückgängigknopfes",
-      "hint" : "Zeigt das Symbol und die Beschriftung oder nur das Symbol der Rückgängigfunktion."
-    },
-    "updateDelay" : {
-      "name" : "Aktualisierungsverzögerung (ms)",
-      "hint" : "Vorübergehender Workaround. Erhöhe diesen Wert wenn du Probleme mit doppelte Platzierung hast. Setze den Wert herunter für eine schnellen Platzierung."
-    },
-    "alwaysAccept": {
-      "name": "Veränderungsanfragen immer akzeptieren",
-      "hint": "Akzeptiere Veränderungen automatisch und unterdrücke den Anfragedialog."
-    },
-    "dismissButtonScope": {
-      "name": "Geltungsbereich Freigabebutton ",
-      "hint": "Legt fest, wann der Freigaebutton zu den Akteursheets hinzugefügt wird."
-    },
-    "revertButtonBehavior": {
-      "name": "Verhalten Rückgängigknopf",
-      "hint": "Standardaktion when der Knopf betätigt wird. Shift+Klick wird das zweite Verhalten ausführen."
-    },
-    "option": {
-      "disabled": "Deaktiviert",
-      "spawnedOnly": "Nur platzierte Tokens",
-      "all": "Alle Tokens im Besitz",
-      "showMutationList": "Zeige den Mutationsstapeldialog",
-      "popLatestMutation": "Mache die letzte Mutations Rückgängig"
-    }
-  },
-  "debug": {
-    "dismissPresent": "Entferne vorhandene Knöpfe. Fügt keine Duplikate hinzu.",
-    "finalRevertUpdate": "Letzte rückgängig gemacht Änderung:",
-    "tokenDelta": "Token Delta",
-    "actorDelta": "Akteur Delta",
-    "embeddedDelta": "Eingebettetes Delta"
-  },
-  "display" : {
-    "dismiss" : "Entferne",
-    "revert" : "Zurücknehmen",
-    "revertDialogTitle" : "Wähle die zurückzunehmende Mutation",
-    "inspectLabel": "Inspizieren",
-    "descriptionLabel": "Beschreibung",
-    "mutationRequestTitle": "{userName} mutiert {tokenName}",
-    "mutationAccepted": "Mutation \"{mName}\" für {tName} wurde freigegeben.",
-    "mutationRejected": "Mutation \"{mName}\" fü {tName} wurde abgelehnt.",
-    "revertAccepted": "Die Zurücknahme der Mutation [{mName}] für {tName} wurde freigegeben.",
-    "revertRejected": "Die Zurücknahme der Mutation [{mName}] für {tName} wurde abgelehnt.",
-    "revertRequestDescription": "Nehme Mutation [{mName}] von {tName} zurück.",
-    "acceptLabel": "Akzeptieren",
-    "rejectLabel": "Ablehnen",
-    "findTargetLabel": "Finde Ziel"
-  },
-  "error" : {
-    "noGm" : "Es ist kein Spielleiter für die Freigabeanfrage verfügbar.",
-    "unownedDelete" : "Löschen nicht im Besitz befindlicher Token nicht möglich.",
-    "createItem": "Erstelle Element",
-    "updateItem": "Aktualisiere Element",
-    "deleteItem": "Lösche Element",
-    "sheetNoToken": "Konnte keine mit dem Bogen verbundene Figur finden.",
-    "findActorFail": "Konnte in der Welt keinen Akteur {name} finden.",
-    "findProtoFail": "Konnte keine Prototyp Figur für {name} finden",
-    "noOpenLocation": "Konnte keine freien Flächen nahe des gewählten Punktes finden. Setze stattdessen auf gewählter Fläche.",
-    "noOwningUserMutate": "Kein User mit Besitzerrechten online. Mutationsanfrage kann nicht durchgeführt werden.",
-    "noOwningUserRevert": "Kein User mit Besitzerrechten online. Rücknahmeanfrage kann nicht durchgeführt werden.",
-    "incompleteMutateInfo": "Überschreiben-Modus für Stapelaktualisierung aktiv, aber das 'name' Feld fehlt.",
-    "stackLockedOrEmpty": "Der Mutationsstapel wurde nicht geändert oder ist für die Bearbeitung gesperrt. Kann keine Änderungen am Stapel durchführen.",
-    "badMutate": {
-      "missing": {
-        "type": "{embeddedName} Füge fehlendes 'type' Feld hinzu. Sollte dies eine Aktualisierung sein? Kontrolliere die Vergleichsschüssel und den {embeddedName} identifier."
+    "error" : {
+      "noGm" : "Es ist kein Spielleiter für die Freigabeanfrage verfügbar.",
+      "unownedDelete" : "Löschen nicht im Besitz befindlicher Token nicht möglich.",
+      "createItem": "Erstelle Element",
+      "updateItem": "Aktualisiere Element",
+      "deleteItem": "Lösche Element",
+      "sheetNoToken": "Konnte keine mit dem Bogen verbundene Figur finden.",
+      "findActorFail": "Konnte in der Welt keinen Akteur {name} finden.",
+      "findProtoFail": "Konnte keine Prototyp Figur für {name} finden",
+      "noOpenLocation": "Konnte keine freien Flächen nahe des gewählten Punktes finden. Setze stattdessen auf gewählter Fläche.",
+      "noOwningUserMutate": "Kein User mit Besitzerrechten online. Mutationsanfrage kann nicht durchgeführt werden.",
+      "noOwningUserRevert": "Kein User mit Besitzerrechten online. Rücknahmeanfrage kann nicht durchgeführt werden.",
+      "incompleteMutateInfo": "Überschreiben-Modus für Stapelaktualisierung aktiv, aber das 'name' Feld fehlt.",
+      "stackLockedOrEmpty": "Der Mutationsstapel wurde nicht geändert oder ist für die Bearbeitung gesperrt. Kann keine Änderungen am Stapel durchführen.",
+      "badMutate": {
+        "missing": {
+          "type": "{embeddedName} Füge fehlendes 'type' Feld hinzu. Sollte dies eine Aktualisierung sein? Kontrolliere die Vergleichsschüssel und den {embeddedName} identifier."
+        }
       }
     }
-  }
 
+  }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,87 +1,90 @@
 {
-  "setting" : {
-    "debug" : {
-      "name" : "Debug",
-      "hint" : "Enables extended debug logging and data collection"
+  "warpgate": {
+    "setting" : {
+      "debug" : {
+        "name" : "Debug",
+        "hint" : "Enables extended debug logging and data collection"
+      },
+      "openDelete" : {
+        "name" : "Unrestricted dismissal",
+        "hint" : "Allows players to dismiss unowned tokens"
+      },
+      "showDismissLabel" : {
+        "name" : "Show dismiss button label",
+        "hint" : "Show the dismiss icon and label, or just the icon on the sheet header."
+      },
+      "showRevertLabel" : {
+        "name" : "Show revert button label",
+        "hint" : "Show the revert icon and label, or just the icon on the sheet header."
+      },
+      "updateDelay" : {
+        "name" : "Update delay (ms)",
+        "hint" : "Temporary workaround. Increase this value if you are encountering errors with duplicate placement. Lower this value for faster placement."
+      },
+      "alwaysAccept": {
+        "name": "Always accept mutation requests",
+        "hint": "If checked, request dialog will not be shown and blindly accepted."
+      },
+      "dismissButtonScope": {
+        "name": "Dismiss button scope",
+        "hint": "Determines when the dismiss button is added to actor sheets."
+      },
+      "revertButtonBehavior": {
+        "name": "Revert button behavior",
+        "hint": "Default action when the button is clicked. Shift+Click will perform the other behavior."
+      },
+      "option": {
+        "disabled": "Disabled",
+        "spawnedOnly": "Spawned tokens only",
+        "all": "All owned tokens",
+        "showMutationList": "Show mutation stack dialog",
+        "popLatestMutation": "Revert last mutation"
+      }
     },
-    "openDelete" : {
-      "name" : "Unrestricted dismissal",
-      "hint" : "Allows players to dismiss unowned tokens"
+    "debug": {
+      "dismissPresent": "Dismiss button already present. Not adding duplicate.",
+      "finalRevertUpdate": "Final revert update:",
+      "tokenDelta": "Token Delta",
+      "actorDelta": "Actor Delta",
+      "embeddedDelta": "Embedded Delta"
     },
-    "showDismissLabel" : {
-      "name" : "Show dismiss button label",
-      "hint" : "Show the dismiss icon and label, or just the icon on the sheet header."
+    "display" : {
+      "dismiss" : "Dismiss",
+      "revert" : "Revert",
+      "revertDialogTitle" : "Select mutation to revert",
+      "inspectLabel": "Inspect",
+      "descriptionLabel": "Description",
+      "mutationRequestTitle": "{userName} is mutating {tokenName}",
+      "mutationAccepted": "Mutation \"{mName}\" for {tName} has been accepted.",
+      "mutationRejected": "Mutation \"{mName}\" for {tName} has been rejected.",
+      "revertAccepted": "Revert of mutation [{mName}] for {tName} has been accepted.",
+      "revertRejected": "Revert of mutation [{mName}] for {tName} has been rejected.",
+      "revertRequestDescription": "Reverting mutation [{mName}] from {tName}.",
+      "acceptLabel": "Accept",
+      "rejectLabel": "Reject",
+      "findTargetLabel": "Find Target"
     },
-    "showRevertLabel" : {
-      "name" : "Show revert button label",
-      "hint" : "Show the revert icon and label, or just the icon on the sheet header."
-    },
-    "updateDelay" : {
-      "name" : "Update delay (ms)",
-      "hint" : "Temporary workaround. Increase this value if you are encountering errors with duplicate placement. Lower this value for faster placement."
-    },
-    "alwaysAccept": {
-      "name": "Always accept mutation requests",
-      "hint": "If checked, request dialog will not be shown and blindly accepted."
-    },
-    "dismissButtonScope": {
-      "name": "Dismiss button scope",
-      "hint": "Determines when the dismiss button is added to actor sheets."
-    },
-    "revertButtonBehavior": {
-      "name": "Revert button behavior",
-      "hint": "Default action when the button is clicked. Shift+Click will perform the other behavior."
-    },
-    "option": {
-      "disabled": "Disabled",
-      "spawnedOnly": "Spawned tokens only",
-      "all": "All owned tokens",
-      "showMutationList": "Show mutation stack dialog",
-      "popLatestMutation": "Revert last mutation"
-    }
-  },
-  "debug": {
-    "dismissPresent": "Dismiss button already present. Not adding duplicate.",
-    "finalRevertUpdate": "Final revert update:",
-    "tokenDelta": "Token Delta",
-    "actorDelta": "Actor Delta",
-    "embeddedDelta": "Embedded Delta"
-  },
-  "display" : {
-    "dismiss" : "Dismiss",
-    "revert" : "Revert",
-    "revertDialogTitle" : "Select mutation to revert",
-    "inspectLabel": "Inspect",
-    "descriptionLabel": "Description",
-    "mutationRequestTitle": "{userName} is mutating {tokenName}",
-    "mutationAccepted": "Mutation \"{mName}\" for {tName} has been accepted.",
-    "mutationRejected": "Mutation \"{mName}\" for {tName} has been rejected.",
-    "revertAccepted": "Revert of mutation [{mName}] for {tName} has been accepted.",
-    "revertRejected": "Revert of mutation [{mName}] for {tName} has been rejected.",
-    "revertRequestDescription": "Reverting mutation [{mName}] from {tName}.",
-    "acceptLabel": "Accept",
-    "rejectLabel": "Reject",
-    "findTargetLabel": "Find Target"
-  },
-  "error" : {
-    "noGm" : "There is no GM available for dismiss request.",
-    "unownedDelete" : "Cannot delete unowned token.",
-    "createItem": "Creating Item",
-    "updateItem": "Updating Item",
-    "deleteItem": "Deleting Item",
-    "sheetNoToken": "Could not find token associated with this sheet.",
-    "findActorFail": "Could not find world actor named {name}",
-    "findProtoFail": "Could not find proto-token data for {name}",
-    "noOpenLocation": "Could not locate open locations near chosen spawn point. Spawning at chosen point instead.",
-    "noOwningUserMutate": "No owning user online. Mutation request cannot be fullfilled.",
-    "noOwningUserRevert": "No owning user online. Revert request cannot be fullfilled.",
-    "incompleteMutateInfo": "Overwrite mode used for stack update, but no 'name' field provided.",
-    "stackLockedOrEmpty": "Mutation stack has no changes or is locked for writing. Cannot commit changes to the stack.",
-    "badMutate": {
-      "missing": {
-        "type": "{embeddedName} Add data missing 'type' field. Was this supposed to be an Update instead? Double-check comparison keys and {embeddedName} identifier."
+    "error" : {
+      "missingPerms": "Operation blocked due to missing user permissions: {permList}.",
+      "noGm" : "There is no GM available for dismiss request.",
+      "unownedDelete" : "Cannot delete unowned token.",
+      "createItem": "Creating Item",
+      "updateItem": "Updating Item",
+      "deleteItem": "Deleting Item",
+      "sheetNoToken": "Could not find token associated with this sheet.",
+      "findActorFail": "Could not find world actor named {name}",
+      "findProtoFail": "Could not find proto-token data for {name}",
+      "noOpenLocation": "Could not locate open locations near chosen spawn point. Spawning at chosen point instead.",
+      "noOwningUserMutate": "No owning user online. Mutation request cannot be fullfilled.",
+      "noOwningUserRevert": "No owning user online. Revert request cannot be fullfilled.",
+      "incompleteMutateInfo": "Overwrite mode used for stack update, but no 'name' field provided.",
+      "stackLockedOrEmpty": "Mutation stack has no changes or is locked for writing. Cannot commit changes to the stack.",
+      "badMutate": {
+        "missing": {
+          "type": "{embeddedName} Add data missing 'type' field. Was this supposed to be an Update instead? Double-check comparison keys and {embeddedName} identifier."
+        }
       }
     }
-  }
 
+  }
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,87 +1,89 @@
 {
-  "setting" : {
-    "debug" : {
-      "nom" : "Déboguer",
-      "hint" : "Active la journalisation de débogage et la collecte de données."
+  "warpgate": {
+    "setting" : {
+      "debug" : {
+        "name" : "Déboguer",
+        "hint" : "Active la journalisation de débogage et la collecte de données."
+      },
+      "openDelete" : {
+        "name" : "Révocation sans restrictions",
+        "hint" : "Permet aux joueurs de rejeter les jetons non possédés."
+      },
+      "showDismissLabel" : {
+        "name" : "Afficher le libellé du bouton de rejet",
+        "indice" : "Afficher l'icône et le libellé de fermeture, ou simplement l'icône sur l'en-tête de la feuille." 
+      },
+      "showRevertLabel" : {
+        "name" : "Afficher le libellé du bouton de retour",
+        "hint" : "Afficher l'icône et l'étiquette de restauration, ou simplement l'icône sur l'en-tête de la feuille." 
+      },
+      "updateDelay" : {
+        "name" : "Délai de mise à jour (ms)",
+        "hint" : "Solution temporaire. Augmentez cette valeur si vous rencontrez des erreurs avec le placement en double. Réduisez cette valeur pour un placement plus rapide."
+      },
+      "alwaysAccept": {
+        "name": "Always accept mutation requests",
+        "hint": "If checked, request dialog will not be shown and blindly accepted."
+      },
+      "dismissButtonScope": {
+        "name": "Dismiss button scope",
+        "hint": "Determines when the dismiss button is added to actor sheets."
+      },
+      "revertButtonBehavior": {
+        "name": "Revert button behavior",
+        "hint": "Default action when the button is clicked. Shift+Click will perform the other behavior."
+      },
+      "option": {
+        "disabled": "Disabled",
+        "spawnedOnly": "Spawned tokens only",
+        "all": "All owned tokens",
+        "showMutationList": "Show mutation stack dialog",
+        "popLatestMutation": "Revert last mutation"
+      }
     },
-    "openDelete" : {
-      "name" : "Révocation sans restrictions",
-      "hint" : "Permet aux joueurs de rejeter les jetons non possédés."
+    "debug": {
+      "dismissPresent": "Dismiss button already present. Not adding duplicate.",
+      "finalRevertUpdate": "Final revert update:",
+      "tokenDelta": "Token Delta",
+      "actorDelta": "Actor Delta",
+      "embeddedDelta": "Embedded Delta"
     },
-    "showDismissLabel" : {
-      "name" : "Afficher le libellé du bouton de rejet",
-      "indice" : "Afficher l'icône et le libellé de fermeture, ou simplement l'icône sur l'en-tête de la feuille." 
+    "display" : {
+      "dismiss" : "Rejeter",
+      "revert" : "Rétablir",
+      "revertDialogTitle" : "Sélectionnez la mutation à rétablir",
+      "inspectLabel": "Inspect",
+      "descriptionLabel": "Description",
+      "mutationRequestTitle": "{userName} is mutating {tokenName}",
+      "mutationAccepted": "Mutation \"{mName}\" for {tName} has been accepted.",
+      "mutationRejected": "Mutation \"{mName}\" for {tName} has been rejected.",
+      "revertAccepted": "Revert of mutation [{mName}] for {tName} has been accepted.",
+      "revertRejected": "Revert of mutation [{mName}] for {tName} has been rejected.",
+      "revertRequestDescription": "Reverting mutation [{mName}] from {tName}.",
+      "acceptLabel": "Accept",
+      "rejectLabel": "Reject",
+      "findTargetLabel": "Find Target"
     },
-    "showRevertLabel" : {
-      "name" : "Afficher le libellé du bouton de retour",
-      "hint" : "Afficher l'icône et l'étiquette de restauration, ou simplement l'icône sur l'en-tête de la feuille." 
-    },
-    "updateDelay" : {
-      "name" : "Délai de mise à jour (ms)",
-      "hint" : "Solution temporaire. Augmentez cette valeur si vous rencontrez des erreurs avec le placement en double. Réduisez cette valeur pour un placement plus rapide."
-    },
-    "alwaysAccept": {
-      "name": "Always accept mutation requests",
-      "hint": "If checked, request dialog will not be shown and blindly accepted."
-    },
-    "dismissButtonScope": {
-      "name": "Dismiss button scope",
-      "hint": "Determines when the dismiss button is added to actor sheets."
-    },
-    "revertButtonBehavior": {
-      "name": "Revert button behavior",
-      "hint": "Default action when the button is clicked. Shift+Click will perform the other behavior."
-    },
-    "option": {
-      "disabled": "Disabled",
-      "spawnedOnly": "Spawned tokens only",
-      "all": "All owned tokens",
-      "showMutationList": "Show mutation stack dialog",
-      "popLatestMutation": "Revert last mutation"
-    }
-  },
-  "debug": {
-    "dismissPresent": "Dismiss button already present. Not adding duplicate.",
-    "finalRevertUpdate": "Final revert update:",
-    "tokenDelta": "Token Delta",
-    "actorDelta": "Actor Delta",
-    "embeddedDelta": "Embedded Delta"
-  },
-  "display" : {
-    "dismiss" : "Rejeter",
-    "revert" : "Rétablir",
-    "revertDialogTitle" : "Sélectionnez la mutation à rétablir",
-    "inspectLabel": "Inspect",
-    "descriptionLabel": "Description",
-    "mutationRequestTitle": "{userName} is mutating {tokenName}",
-    "mutationAccepted": "Mutation \"{mName}\" for {tName} has been accepted.",
-    "mutationRejected": "Mutation \"{mName}\" for {tName} has been rejected.",
-    "revertAccepted": "Revert of mutation [{mName}] for {tName} has been accepted.",
-    "revertRejected": "Revert of mutation [{mName}] for {tName} has been rejected.",
-    "revertRequestDescription": "Reverting mutation [{mName}] from {tName}.",
-    "acceptLabel": "Accept",
-    "rejectLabel": "Reject",
-    "findTargetLabel": "Find Target"
-  },
-  "error" : {
-    "noGm" : "Il n'y a pas de MJ disponible pour une demande de rejet.",
-    "unownedDelete": "Impossible de supprimer le jeton sans propriétaire.",
-    "createItem": "Création d'un élément",
-    "updateItem": "Mise à jour de l'élément",
-    "deleteItem": "Suppression d'un élément",
-    "sheetNoToken": "Impossible de trouver le jeton associé à cette feuille.",
-    "findActorFail": "Impossible de trouver l'acteur sur ce monde nommé {name}",
-    "findProtoFail": "Impossible de trouver les données de proto-jeton pour {name}",
-    "noOpenLocation": "Impossible de localiser les emplacements ouverts à proximité du point d'apparition choisi. Reproduire au point choisi à la place.",
-    "noOwningUserMutate": "No owning user online. Mutation request cannot be fullfilled",
-    "noOwningUserRevert": "No owning user online. Revert request cannot be fullfilled.",
-    "incompleteMutateInfo": "Overwrite mode used for stack update, but no 'name' field provided.",
-    "stackLockedOrEmpty": "Mutation stack has no changes or is locked for writing. Cannot commit changes to the stack.",
-    "badMutate": {
-      "missing": {
-        "type": "{embeddedName} Add data missing 'type' field. Was this supposed to be an Update instead? Double-check comparison keys and {embeddedName} identifier."
+    "error" : {
+      "noGm" : "Il n'y a pas de MJ disponible pour une demande de rejet.",
+      "unownedDelete": "Impossible de supprimer le jeton sans propriétaire.",
+      "createItem": "Création d'un élément",
+      "updateItem": "Mise à jour de l'élément",
+      "deleteItem": "Suppression d'un élément",
+      "sheetNoToken": "Impossible de trouver le jeton associé à cette feuille.",
+      "findActorFail": "Impossible de trouver l'acteur sur ce monde nommé {name}",
+      "findProtoFail": "Impossible de trouver les données de proto-jeton pour {name}",
+      "noOpenLocation": "Impossible de localiser les emplacements ouverts à proximité du point d'apparition choisi. Reproduire au point choisi à la place.",
+      "noOwningUserMutate": "No owning user online. Mutation request cannot be fullfilled",
+      "noOwningUserRevert": "No owning user online. Revert request cannot be fullfilled.",
+      "incompleteMutateInfo": "Overwrite mode used for stack update, but no 'name' field provided.",
+      "stackLockedOrEmpty": "Mutation stack has no changes or is locked for writing. Cannot commit changes to the stack.",
+      "badMutate": {
+        "missing": {
+          "type": "{embeddedName} Add data missing 'type' field. Was this supposed to be an Update instead? Double-check comparison keys and {embeddedName} identifier."
+        }
       }
     }
-  }
 
+  }
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,87 +1,89 @@
 {
-  "setting" : {
-    "debug" : {
-      "name" : "デバッグの有効化",
-      "hint" : "拡張デバッグログとデータ収集を有効にします。"
+  "warpgate": {
+    "setting" : {
+      "debug" : {
+        "name" : "デバッグの有効化",
+        "hint" : "拡張デバッグログとデータ収集を有効にします。"
+      },
+      "openDelete" : {
+        "name" : "退去の無制限化",
+        "hint" : "プレイヤーに所有権のないコマの退去を許可します。"
+      },
+      "showDismissLabel" : {
+        "name" : "退去ボタンにラベルを表示する",
+        "hint" : "シートのヘッダに表示される退去アイコンに、ラベルを表示するかを設定します。"
+      },
+      "showRevertLabel" : {
+        "name" : "復元ボタンにラベルを表示する",
+        "hint" : "シートのヘッダに表示される復元アイコンに、ラベルを表示するかを設定します。"
+      },
+      "updateDelay" : {
+        "name" : "更新ディレイ（ms）",
+        "hint" : "一時的な回避策です。重複配置エラーが発生する場合は値を大きくしてください。より高速に配置するには、この値を小さくします。"
+      },
+      "alwaysAccept": {
+        "name": "改変申請を常に受け入れる",
+        "hint": "有効にすると、申請ダイアログが表示されることなく自動的に受諾が行われます。"
+      },
+      "dismissButtonScope": {
+        "name": "退去ボタンの追加範囲",
+        "hint": "退去ボタンを追加するアクターシートを設定します。"
+      },
+      "revertButtonBehavior": {
+        "name": "復元ボタンの挙動",
+        "hint": "ボタンを押したときの標準動作です。［Shift］＋クリックで別の動作になります。"
+      },
+      "option": {
+        "disabled": "無効",
+        "spawnedOnly": "生成されたコマのみ",
+        "all": "所有権を持つすべてのコマ",
+        "showMutationList": "改変履歴ダイアログを表示する",
+        "popLatestMutation": "直近の改変を復元する"
+      }
     },
-    "openDelete" : {
-      "name" : "退去の無制限化",
-      "hint" : "プレイヤーに所有権のないコマの退去を許可します。"
+    "debug": {
+      "dismissPresent": "退去ボタンはすでに存在しています。重複した追加は行えません。",
+      "finalRevertUpdate": "最後に更新された復元：",
+      "tokenDelta": "トークンのデルタ",
+      "actorDelta": "アクターのデルタ",
+      "embeddedDelta": "埋め込まれたデルタ"
     },
-    "showDismissLabel" : {
-      "name" : "退去ボタンにラベルを表示する",
-      "hint" : "シートのヘッダに表示される退去アイコンに、ラベルを表示するかを設定します。"
+    "display" : {
+      "dismiss" : "退去",
+      "revert" : "復元",
+      "revertDialogTitle" : "復元する改変を選択してください",
+      "inspectLabel": "検査",
+      "descriptionLabel": "概要",
+      "mutationRequestTitle": "{userName} が {tokenName} を改変しています。",
+      "mutationAccepted": "{tName} に対する改変 \"{mName}\" を受理されました。",
+      "mutationRejected": "{tName} に対する改変 \"{mName}\" が拒否されました。",
+      "revertAccepted": "{tName}に対する改変[{mName}]の復元が受理されました。",
+      "revertRejected": "{tName}に対する改変[{mName}]の復元が拒否されました。",
+      "revertRequestDescription": "[{mName}]の改変を{tName}に復元しています。",
+      "acceptLabel": "許諾",
+      "rejectLabel": "拒否",
+      "findTargetLabel": "目標を探す"
     },
-    "showRevertLabel" : {
-      "name" : "復元ボタンにラベルを表示する",
-      "hint" : "シートのヘッダに表示される復元アイコンに、ラベルを表示するかを設定します。"
-    },
-    "updateDelay" : {
-      "name" : "更新ディレイ（ms）",
-      "hint" : "一時的な回避策です。重複配置エラーが発生する場合は値を大きくしてください。より高速に配置するには、この値を小さくします。"
-    },
-    "alwaysAccept": {
-      "name": "改変申請を常に受け入れる",
-      "hint": "有効にすると、申請ダイアログが表示されることなく自動的に受諾が行われます。"
-    },
-    "dismissButtonScope": {
-      "name": "退去ボタンの追加範囲",
-      "hint": "退去ボタンを追加するアクターシートを設定します。"
-    },
-    "revertButtonBehavior": {
-      "name": "復元ボタンの挙動",
-      "hint": "ボタンを押したときの標準動作です。［Shift］＋クリックで別の動作になります。"
-    },
-    "option": {
-      "disabled": "無効",
-      "spawnedOnly": "生成されたコマのみ",
-      "all": "所有権を持つすべてのコマ",
-      "showMutationList": "改変履歴ダイアログを表示する",
-      "popLatestMutation": "直近の改変を復元する"
-    }
-  },
-  "debug": {
-    "dismissPresent": "退去ボタンはすでに存在しています。重複した追加は行えません。",
-    "finalRevertUpdate": "最後に更新された復元：",
-    "tokenDelta": "トークンのデルタ",
-    "actorDelta": "アクターのデルタ",
-    "embeddedDelta": "埋め込まれたデルタ"
-  },
-  "display" : {
-    "dismiss" : "退去",
-    "revert" : "復元",
-    "revertDialogTitle" : "復元する改変を選択してください",
-    "inspectLabel": "検査",
-    "descriptionLabel": "概要",
-    "mutationRequestTitle": "{userName} が {tokenName} を改変しています。",
-    "mutationAccepted": "{tName} に対する改変 \"{mName}\" を受理されました。",
-    "mutationRejected": "{tName} に対する改変 \"{mName}\" が拒否されました。",
-    "revertAccepted": "{tName}に対する改変[{mName}]の復元が受理されました。",
-    "revertRejected": "{tName}に対する改変[{mName}]の復元が拒否されました。",
-    "revertRequestDescription": "[{mName}]の改変を{tName}に復元しています。",
-    "acceptLabel": "許諾",
-    "rejectLabel": "拒否",
-    "findTargetLabel": "目標を探す"
-  },
-  "error" : {
-    "noGm" : "退去リクエストに対応するGMがいません。",
-    "unownedDelete" : "所有権のないコマは削除できません。",
-    "createItem": "アイテムを作成しています。",
-    "updateItem": "アイテムを更新しています。",
-    "deleteItem": "アイテムを削除しています。",
-    "sheetNoToken": "このシートに関連するコマが見つかりません。",
-    "findActorFail": "{name} という名のワールドアクターが見つかりません。",
-    "findProtoFail": "{name} のプロトタイプトークンデータが見つかりません。",
-    "noOpenLocation": "選択した場所の付近に開いた場所が見つかりませんでした。代わりに選択した地点にスポーンします。",
-    "noOwningUserMutate": "所有するユーザーがオフラインです。改変リクエストに応じられません。",
-    "noOwningUserRevert": "所有するユーザーがオフラインです。復元リクエストを完了できません。",
-    "incompleteMutateInfo": "上書きモードで履歴の更新を試みましたが、'name'フィールドが提供されませんでした。",
-    "stackLockedOrEmpty": "改変履歴に変更がないか、書込がロックされています。履歴の変更を完了できません。",
-    "badMutate": {
-      "missing": {
-        "type": "{embeddedName}の追加データに'type'フィールドがありません。これは更新でしょうか。比較キーと{embeddedName}の識別子を再確認してください。"
+    "error" : {
+      "noGm" : "退去リクエストに対応するGMがいません。",
+      "unownedDelete" : "所有権のないコマは削除できません。",
+      "createItem": "アイテムを作成しています。",
+      "updateItem": "アイテムを更新しています。",
+      "deleteItem": "アイテムを削除しています。",
+      "sheetNoToken": "このシートに関連するコマが見つかりません。",
+      "findActorFail": "{name} という名のワールドアクターが見つかりません。",
+      "findProtoFail": "{name} のプロトタイプトークンデータが見つかりません。",
+      "noOpenLocation": "選択した場所の付近に開いた場所が見つかりませんでした。代わりに選択した地点にスポーンします。",
+      "noOwningUserMutate": "所有するユーザーがオフラインです。改変リクエストに応じられません。",
+      "noOwningUserRevert": "所有するユーザーがオフラインです。復元リクエストを完了できません。",
+      "incompleteMutateInfo": "上書きモードで履歴の更新を試みましたが、'name'フィールドが提供されませんでした。",
+      "stackLockedOrEmpty": "改変履歴に変更がないか、書込がロックされています。履歴の変更を完了できません。",
+      "badMutate": {
+        "missing": {
+          "type": "{embeddedName}の追加データに'type'フィールドがありません。これは更新でしょうか。比較キーと{embeddedName}の識別子を再確認してください。"
+        }
       }
     }
-  }
 
+  }
 }

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -114,6 +114,13 @@ export class api {
    * @return Promise<[{String}]> list of created token ids
    */
   static async _spawn(spawnName, updates = {}, callbacks = {}, options = {}) {
+    
+    /* check for needed spawning permissions */
+    const neededPerms = MODULE.canSpawn(game.user);
+    if(neededPerms.length > 0) {
+      logger.warn(MODULE.format('error.missingPerms', {permList: neededPerms.join(', ')}));
+      return [];
+    }
 
     /* create permissions for this user */
     const ownershipKey = MODULE.isV10 ? "ownership" : "permission";
@@ -174,6 +181,13 @@ export class api {
    * 4) if more duplicates, get fresh proto data and update it, goto 1
    */
   static async _spawnAt(spawnLocation, protoData, updates = {}, callbacks = {}, options = {}) {
+
+    /* check for needed spawning permissions */
+    const neededPerms = MODULE.canSpawn(game.user);
+    if(neededPerms.length > 0) {
+      logger.warn(MODULE.format('error.missingPerms', {permList: neededPerms.join(', ')}));
+      return [];
+    }
 
     updates = MODULE.shimUpdate(updates);
 

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -34,6 +34,7 @@ export class logger {
 
   static warn(...args) {
     console.warn(`${MODULE?.data?.title ?? "" } | WARNING | `, ...args);
+    ui.notifications.warn(`${MODULE?.data?.title ?? "" } | WARNING | ${args[0]}`);
   }
 
   static error(...args) {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -30,12 +30,40 @@ export class MODULE {
     return game.settings.get(MODULE.data.name, key);
   }
 
-  static localize(...args) {
-    return game.i18n.localize(...args);
+  static localize(key) {
+    return game.i18n.localize(`warpgate.${key}`);
   }
 
-  static format(...args) {
-    return game.i18n.format(...args);
+  static format(key, data) {
+    return game.i18n.format(`warpgate.${key}`, data);
+  }
+
+  static canSpawn(user) {
+    const reqs = [
+      'TOKEN_CREATE',
+      'TOKEN_CONFIGURE',
+      'FILES_BROWSE',
+    ]
+
+    return MODULE.canUser(user, reqs);
+  }
+
+  static canMutate(user) {
+    const reqs = [
+      'TOKEN_CONFIGURE',
+      'FILES_BROWSE',
+    ]
+
+    return MODULE.canUser(user, reqs);
+  }
+
+  /**
+   * @return {Array<String>} missing permissions for this operation
+   */
+  static canUser(user, requiredPermissions) {
+    const {role} = user;
+    const permissions = game.settings.get('core','permissions');
+    return requiredPermissions.filter( req => !permissions[req].includes(role) ).map(missing => game.i18n.localize(CONST.USER_PERMISSIONS[missing].label));
   }
 
   static firstGM() {


### PR DESCRIPTION
Reduced event payload size by removing the packed actor data. See readme for updated event data payloads. Primary change is replacing 'actorData' with 'uuid' (of the spawned/modified token).