### PR TITLE
Add type to checkCollision to avoid thrown error

### DIFF
--- a/scripts/propagator.js
+++ b/scripts/propagator.js
@@ -70,7 +70,7 @@ export class Propagator{
       new Ray(origin, {
         x:position.x+tokenData.width*canvas.scene.dimensions.size/2,
         y:position.y+tokenData.height*canvas.scene.dimensions.size/2
-      })
+      }),{ type: "move" }
     )?.length ?? 0;
 
 


### PR DESCRIPTION
"move" is the v9 default type, but v10 requires a type to be declared in checkCollision, otherwise an error is thrown.

See
https://github.com/trioderegion/warpgate/issues/94
https://github.com/trioderegion/warpgate/issues/77