### PR TITLE
add updateOpts to spawnAt's _updateActor call

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -583,7 +583,7 @@ export class api {
 
       logger.debug('Spawned token with data: ', spawnedTokenDoc);
 
-      await _updateActor(spawnedTokenDoc.actor, updates, options.comparisonKeys ?? {});
+      await _updateActor(spawnedTokenDoc.actor, updates, options.comparisonKeys ?? {}, options.updateOpts ?? {});
 
       const eventPayload = {
         uuid: spawnedTokenDoc.uuid,


### PR DESCRIPTION
the _updateActor call from spawnAt() to apply post-spawn mutations was missing the updateOpts parameter that is present when _updateActor is eventually called from muatate(). This fixes that, allowing updateOpts to be passed to spawn mutations as well.

(this change has been tested, but does not itself update the `dist` directory because there were a bunch of unexpected changes to `warpgate.js` when I tried to build, and I'm not sure if I just have different versions of tools or if I've missed something in the build process for this project)